### PR TITLE
Appliance energy simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ mock-data
 playwright-report
 test-results
 public/client-entry.js
+public/mcp-appliance-app.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,4 @@ yarn.lock
 pnpm-lock.yaml
 **/worker-configuration.d.ts
 public/client-entry.js
+public/mcp-appliance-app.js

--- a/README.md
+++ b/README.md
@@ -27,12 +27,34 @@ clients.
 - Lets you add appliances by watts or by amps + volts (stored as watts).
 - Shows a running total of watts across all appliances.
 - Supports deleting appliances to keep totals accurate.
-- Exposes MCP tools for list, add, delete, and total-watts flows.
+- Exposes MCP tools for list, add, edit, delete, and total-watts flows.
+- Exposes an MCP App launch tool (`open_appliance_energy_app`) that opens an
+  interactive appliance simulation UI in MCP Apps-compatible hosts.
 
 ## Who It Is For
 
 - People estimating household loads or comparing appliance usage.
 - Teams that want a simple, auditable energy-usage list with automation hooks.
+
+## MCP App: Appliance Energy Simulator
+
+The MCP server now includes an app-launch tool that opens an interactive
+simulator UI with per-appliance knobs. The simulator uses client-side state only
+(no persistence) and calculates:
+
+- Per-appliance daily kWh
+- Total daily kWh
+- Average watts and peak watts
+- 24-hour aggregated load profile
+
+Per-appliance knobs:
+
+- enabled
+- hours per day
+- duty cycle percent
+- start hour
+- quantity
+- optional override watts
 
 ## Project Lineage
 

--- a/client/mcp-appliance-app.tsx
+++ b/client/mcp-appliance-app.tsx
@@ -420,7 +420,7 @@ export function McpApplianceApp(handle: Handle) {
 	}
 
 	function resetControls(ids: Array<number> | null) {
-		if (!ids || ids.length === 0) {
+		if (ids === null) {
 			updateSimulation(
 				applianceRows.map((item) => ({
 					...item,
@@ -429,6 +429,9 @@ export function McpApplianceApp(handle: Handle) {
 			)
 			handle.update()
 			return applianceRows.length
+		}
+		if (ids.length === 0) {
+			return 0
 		}
 		const targetSet = new Set(ids)
 		let changedCount = 0
@@ -602,11 +605,16 @@ export function McpApplianceApp(handle: Handle) {
 	}
 
 	function getSafeAreaPadding() {
+		const safeAreaInsets = hostContext?.safeAreaInsets
+		const top = safeAreaInsets?.top ?? 0
+		const right = safeAreaInsets?.right ?? 0
+		const bottom = safeAreaInsets?.bottom ?? 0
+		const left = safeAreaInsets?.left ?? 0
 		return {
-			paddingTop: hostContext?.safeAreaInsets?.top ?? 0,
-			paddingRight: hostContext?.safeAreaInsets?.right ?? 0,
-			paddingBottom: hostContext?.safeAreaInsets?.bottom ?? 0,
-			paddingLeft: hostContext?.safeAreaInsets?.left ?? 0,
+			paddingTop: `calc(${spacing.md} + ${top}px)`,
+			paddingRight: `calc(${spacing.md} + ${right}px)`,
+			paddingBottom: `calc(${spacing.md} + ${bottom}px)`,
+			paddingLeft: `calc(${spacing.md} + ${left}px)`,
 		}
 	}
 
@@ -631,7 +639,6 @@ export function McpApplianceApp(handle: Handle) {
 					display: 'grid',
 					gridTemplateRows: 'auto auto 1fr',
 					gap: spacing.md,
-					padding: spacing.md,
 					background: colors.background,
 					color: colors.text,
 					fontFamily: typography.fontFamily,

--- a/client/mcp-appliance-app.tsx
+++ b/client/mcp-appliance-app.tsx
@@ -5,6 +5,7 @@ import {
 	type Tool,
 } from '@modelcontextprotocol/sdk/types.js'
 import { type Handle } from 'remix/component'
+import { colors, radius, spacing, typography } from './styles/tokens.ts'
 
 type ConnectionStatus = 'connecting' | 'connected' | 'error'
 
@@ -629,10 +630,11 @@ export function McpApplianceApp(handle: Handle) {
 					boxSizing: 'border-box',
 					display: 'grid',
 					gridTemplateRows: 'auto auto 1fr',
-					gap: '1rem',
-					padding: '1rem',
-					background: '#ffffff',
-					color: '#111827',
+					gap: spacing.md,
+					padding: spacing.md,
+					background: colors.background,
+					color: colors.text,
+					fontFamily: typography.fontFamily,
 				}}
 			>
 				<header
@@ -640,28 +642,34 @@ export function McpApplianceApp(handle: Handle) {
 						display: 'flex',
 						justifyContent: 'space-between',
 						alignItems: 'center',
-						gap: '1rem',
+						gap: spacing.md,
 						flexWrap: 'wrap',
 					}}
 				>
-					<div style={{ display: 'grid', gap: '0.25rem' }}>
-						<h1 style={{ margin: 0, fontSize: '1.25rem' }}>
+					<div style={{ display: 'grid', gap: spacing.xs }}>
+						<h1
+							style={{
+								margin: 0,
+								fontSize: typography.fontSize.lg,
+								fontWeight: typography.fontWeight.semibold,
+							}}
+						>
 							Appliance Energy Simulator
 						</h1>
-						<p style={{ margin: 0, color: '#4b5563' }}>
+						<p style={{ margin: 0, color: colors.textMuted }}>
 							Local-only appliance knobs and load calculations.
 						</p>
 					</div>
 					<p
 						style={{
 							margin: 0,
-							fontWeight: 600,
+							fontWeight: typography.fontWeight.semibold,
 							color:
 								connectionStatus === 'error'
-									? '#b91c1c'
+									? colors.error
 									: connectionStatus === 'connected'
-										? '#047857'
-										: '#92400e',
+										? colors.primaryText
+										: colors.textMuted,
 						}}
 					>
 						{connectionStatus === 'connected'
@@ -676,48 +684,69 @@ export function McpApplianceApp(handle: Handle) {
 					style={{
 						display: 'grid',
 						gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-						gap: '0.75rem',
+						gap: spacing.sm,
 					}}
 				>
 					<article
 						style={{
-							border: '1px solid #e5e7eb',
-							borderRadius: '0.75rem',
-							padding: '0.75rem',
+							border: `1px solid ${colors.border}`,
+							borderRadius: radius.lg,
+							padding: spacing.sm,
 							display: 'grid',
-							gap: '0.25rem',
+							gap: spacing.xs,
+							background: colors.surface,
 						}}
 					>
-						<p style={{ margin: 0, color: '#6b7280' }}>Daily energy</p>
-						<p style={{ margin: 0, fontSize: '1.125rem', fontWeight: 600 }}>
+						<p style={{ margin: 0, color: colors.textMuted }}>Daily energy</p>
+						<p
+							style={{
+								margin: 0,
+								fontSize: typography.fontSize.lg,
+								fontWeight: typography.fontWeight.semibold,
+							}}
+						>
 							{formatKwh(simulation.totals.dailyKwh)}
 						</p>
 					</article>
 					<article
 						style={{
-							border: '1px solid #e5e7eb',
-							borderRadius: '0.75rem',
-							padding: '0.75rem',
+							border: `1px solid ${colors.border}`,
+							borderRadius: radius.lg,
+							padding: spacing.sm,
 							display: 'grid',
-							gap: '0.25rem',
+							gap: spacing.xs,
+							background: colors.surface,
 						}}
 					>
-						<p style={{ margin: 0, color: '#6b7280' }}>Peak load</p>
-						<p style={{ margin: 0, fontSize: '1.125rem', fontWeight: 600 }}>
+						<p style={{ margin: 0, color: colors.textMuted }}>Peak load</p>
+						<p
+							style={{
+								margin: 0,
+								fontSize: typography.fontSize.lg,
+								fontWeight: typography.fontWeight.semibold,
+							}}
+						>
 							{formatWatts(simulation.totals.peakWatts)}
 						</p>
 					</article>
 					<article
 						style={{
-							border: '1px solid #e5e7eb',
-							borderRadius: '0.75rem',
-							padding: '0.75rem',
+							border: `1px solid ${colors.border}`,
+							borderRadius: radius.lg,
+							padding: spacing.sm,
 							display: 'grid',
-							gap: '0.25rem',
+							gap: spacing.xs,
+							background: colors.surface,
 						}}
 					>
-						<p style={{ margin: 0, color: '#6b7280' }}>Average load</p>
-						<p style={{ margin: 0, fontSize: '1.125rem', fontWeight: 600 }}>
+						<p style={{ margin: 0, color: colors.textMuted }}>Average load</p>
+						<p
+							style={{
+								margin: 0,
+								fontSize: typography.fontSize.lg,
+								fontWeight: typography.fontWeight.semibold,
+							}}
+						>
 							{formatWatts(simulation.totals.averageWatts)}
 						</p>
 					</article>
@@ -727,23 +756,26 @@ export function McpApplianceApp(handle: Handle) {
 					style={{
 						display: 'grid',
 						gridTemplateColumns: 'minmax(0, 18rem) minmax(0, 1fr)',
-						gap: '1rem',
+						gap: spacing.md,
 						minHeight: 0,
 					}}
 				>
 					<aside
 						style={{
-							border: '1px solid #e5e7eb',
-							borderRadius: '0.75rem',
-							padding: '0.75rem',
+							border: `1px solid ${colors.border}`,
+							borderRadius: radius.lg,
+							padding: spacing.sm,
 							display: 'grid',
-							gap: '0.75rem',
+							gap: spacing.sm,
 							alignContent: 'start',
 							overflow: 'auto',
+							background: colors.surface,
 						}}
 					>
-						<label style={{ display: 'grid', gap: '0.35rem' }}>
-							<span style={{ fontWeight: 600 }}>Select appliance</span>
+						<label style={{ display: 'grid', gap: spacing.xs }}>
+							<span style={{ fontWeight: typography.fontWeight.semibold }}>
+								Select appliance
+							</span>
 							<select
 								value={selectedApplianceId ?? ''}
 								on={{
@@ -757,10 +789,12 @@ export function McpApplianceApp(handle: Handle) {
 									},
 								}}
 								style={{
-									padding: '0.5rem',
-									borderRadius: '0.5rem',
-									border: '1px solid #d1d5db',
-									background: '#fff',
+									padding: spacing.sm,
+									borderRadius: radius.md,
+									border: `1px solid ${colors.border}`,
+									background: colors.background,
+									color: colors.text,
+									fontFamily: typography.fontFamily,
 								}}
 							>
 								<option value="">Select…</option>
@@ -777,7 +811,7 @@ export function McpApplianceApp(handle: Handle) {
 								margin: 0,
 								paddingLeft: '1.1rem',
 								display: 'grid',
-								gap: '0.35rem',
+								gap: spacing.xs,
 							}}
 						>
 							{simulation.appliances.map((appliance) => (
@@ -791,36 +825,39 @@ export function McpApplianceApp(handle: Handle) {
 
 					<div
 						style={{
-							border: '1px solid #e5e7eb',
-							borderRadius: '0.75rem',
-							padding: '0.75rem',
+							border: `1px solid ${colors.border}`,
+							borderRadius: radius.lg,
+							padding: spacing.sm,
 							display: 'grid',
-							gap: '0.75rem',
+							gap: spacing.sm,
 							alignContent: 'start',
 							overflow: 'auto',
+							background: colors.surface,
 						}}
 					>
 						{connectionMessage ? (
-							<p style={{ margin: 0, color: '#6b7280' }}>{connectionMessage}</p>
+							<p style={{ margin: 0, color: colors.textMuted }}>
+								{connectionMessage}
+							</p>
 						) : null}
 						{loadError ? (
-							<p style={{ margin: 0, color: '#b91c1c' }} role="alert">
+							<p style={{ margin: 0, color: colors.error }} role="alert">
 								{loadError}
 							</p>
 						) : null}
 
 						{selected ? (
-							<section style={{ display: 'grid', gap: '0.75rem' }}>
-								<header style={{ display: 'grid', gap: '0.35rem' }}>
-									<h2 style={{ margin: 0, fontSize: '1rem' }}>
+							<section style={{ display: 'grid', gap: spacing.sm }}>
+								<header style={{ display: 'grid', gap: spacing.xs }}>
+									<h2 style={{ margin: 0, fontSize: typography.fontSize.base }}>
 										{selected.name}
 									</h2>
-									<p style={{ margin: 0, color: '#6b7280' }}>
+									<p style={{ margin: 0, color: colors.textMuted }}>
 										Base: {formatWatts(selected.watts)} · Effective:{' '}
 										{formatWatts(selected.derived.effectiveWatts)}
 									</p>
 									{selected.notes ? (
-										<p style={{ margin: 0, color: '#6b7280' }}>
+										<p style={{ margin: 0, color: colors.textMuted }}>
 											{selected.notes}
 										</p>
 									) : null}
@@ -830,7 +867,7 @@ export function McpApplianceApp(handle: Handle) {
 									style={{
 										display: 'flex',
 										alignItems: 'center',
-										gap: '0.5rem',
+										gap: spacing.sm,
 									}}
 								>
 									<input
@@ -850,7 +887,7 @@ export function McpApplianceApp(handle: Handle) {
 									<span>Enabled</span>
 								</label>
 
-								<label style={{ display: 'grid', gap: '0.35rem' }}>
+								<label style={{ display: 'grid', gap: spacing.xs }}>
 									<span>Hours per day</span>
 									<input
 										type="number"
@@ -868,14 +905,17 @@ export function McpApplianceApp(handle: Handle) {
 											},
 										}}
 										style={{
-											padding: '0.5rem',
-											borderRadius: '0.5rem',
-											border: '1px solid #d1d5db',
+											padding: spacing.sm,
+											borderRadius: radius.md,
+											border: `1px solid ${colors.border}`,
+											background: colors.background,
+											color: colors.text,
+											fontFamily: typography.fontFamily,
 										}}
 									/>
 								</label>
 
-								<label style={{ display: 'grid', gap: '0.35rem' }}>
+								<label style={{ display: 'grid', gap: spacing.xs }}>
 									<span>Duty cycle (%)</span>
 									<input
 										type="number"
@@ -893,14 +933,17 @@ export function McpApplianceApp(handle: Handle) {
 											},
 										}}
 										style={{
-											padding: '0.5rem',
-											borderRadius: '0.5rem',
-											border: '1px solid #d1d5db',
+											padding: spacing.sm,
+											borderRadius: radius.md,
+											border: `1px solid ${colors.border}`,
+											background: colors.background,
+											color: colors.text,
+											fontFamily: typography.fontFamily,
 										}}
 									/>
 								</label>
 
-								<label style={{ display: 'grid', gap: '0.35rem' }}>
+								<label style={{ display: 'grid', gap: spacing.xs }}>
 									<span>Start hour (0–23)</span>
 									<input
 										type="number"
@@ -918,14 +961,17 @@ export function McpApplianceApp(handle: Handle) {
 											},
 										}}
 										style={{
-											padding: '0.5rem',
-											borderRadius: '0.5rem',
-											border: '1px solid #d1d5db',
+											padding: spacing.sm,
+											borderRadius: radius.md,
+											border: `1px solid ${colors.border}`,
+											background: colors.background,
+											color: colors.text,
+											fontFamily: typography.fontFamily,
 										}}
 									/>
 								</label>
 
-								<label style={{ display: 'grid', gap: '0.35rem' }}>
+								<label style={{ display: 'grid', gap: spacing.xs }}>
 									<span>Quantity</span>
 									<input
 										type="number"
@@ -943,14 +989,17 @@ export function McpApplianceApp(handle: Handle) {
 											},
 										}}
 										style={{
-											padding: '0.5rem',
-											borderRadius: '0.5rem',
-											border: '1px solid #d1d5db',
+											padding: spacing.sm,
+											borderRadius: radius.md,
+											border: `1px solid ${colors.border}`,
+											background: colors.background,
+											color: colors.text,
+											fontFamily: typography.fontFamily,
 										}}
 									/>
 								</label>
 
-								<label style={{ display: 'grid', gap: '0.35rem' }}>
+								<label style={{ display: 'grid', gap: spacing.xs }}>
 									<span>Override watts (optional)</span>
 									<input
 										type="number"
@@ -973,9 +1022,12 @@ export function McpApplianceApp(handle: Handle) {
 											},
 										}}
 										style={{
-											padding: '0.5rem',
-											borderRadius: '0.5rem',
-											border: '1px solid #d1d5db',
+											padding: spacing.sm,
+											borderRadius: radius.md,
+											border: `1px solid ${colors.border}`,
+											background: colors.background,
+											color: colors.text,
+											fontFamily: typography.fontFamily,
 										}}
 									/>
 								</label>
@@ -986,12 +1038,12 @@ export function McpApplianceApp(handle: Handle) {
 								</p>
 							</section>
 						) : (
-							<p style={{ margin: 0, color: '#6b7280' }}>
+							<p style={{ margin: 0, color: colors.textMuted }}>
 								Select an appliance to adjust knobs.
 							</p>
 						)}
 
-						<section style={{ display: 'grid', gap: '0.5rem' }}>
+						<section style={{ display: 'grid', gap: spacing.sm }}>
 							<h3 style={{ margin: 0, fontSize: '0.95rem' }}>
 								Hourly load profile
 							</h3>
@@ -1002,10 +1054,10 @@ export function McpApplianceApp(handle: Handle) {
 									alignItems: 'end',
 									gap: '0.2rem',
 									height: '7.5rem',
-									border: '1px solid #e5e7eb',
-									borderRadius: '0.5rem',
+									border: `1px solid ${colors.border}`,
+									borderRadius: radius.md,
 									padding: '0.4rem',
-									background: '#f9fafb',
+									background: colors.background,
 								}}
 							>
 								{simulation.hourlyLoadWatts.map((value, hour) => {
@@ -1017,7 +1069,7 @@ export function McpApplianceApp(handle: Handle) {
 											style={{
 												height: `${Math.max(6, ratio * 100)}%`,
 												borderRadius: '0.2rem',
-												background: '#2563eb',
+												background: colors.primary,
 											}}
 										/>
 									)
@@ -1028,7 +1080,7 @@ export function McpApplianceApp(handle: Handle) {
 									display: 'grid',
 									gridTemplateColumns: 'repeat(12, minmax(0, 1fr))',
 									fontSize: '0.75rem',
-									color: '#6b7280',
+									color: colors.textMuted,
 								}}
 							>
 								{Array.from({ length: 12 }, (_value, index) => (

--- a/client/mcp-appliance-app.tsx
+++ b/client/mcp-appliance-app.tsx
@@ -85,35 +85,6 @@ type SimulationToolPayload = {
 	updatedAt: string
 }
 
-function toBridgeEventSummary(event: MessageEvent) {
-	const data =
-		event.data && typeof event.data === 'object'
-			? (event.data as Record<string, unknown>)
-			: null
-	const jsonrpc = typeof data?.jsonrpc === 'string' ? data.jsonrpc : null
-	const method = typeof data?.method === 'string' ? data.method : null
-	const hasId =
-		typeof data?.id === 'string' || typeof data?.id === 'number'
-	return [
-		`origin=${event.origin || 'unknown'}`,
-		`sourceIsParent=${event.source === window.parent ? 'yes' : 'no'}`,
-		`jsonrpc=${jsonrpc ?? 'none'}`,
-		`method=${method ?? 'none'}`,
-		`hasId=${hasId ? 'yes' : 'no'}`,
-	].join(' ')
-}
-
-function isBridgeDebugEnabled() {
-	return new URLSearchParams(window.location.search).get('bridgeDebug') === '1'
-}
-
-function bridgeDebugBreak(label: string, payload?: unknown) {
-	if (!isBridgeDebugEnabled()) return
-	console.log(`[bridge-debug] ${label}`, payload)
-	// Intentional breakpoint for handshake debugging in MCPJam iframe.
-	debugger
-}
-
 const appInfo = { name: 'Appliance Energy App', version: '1.0.0' }
 
 const appToolDefinitions: Array<Tool> = [
@@ -565,20 +536,6 @@ export function McpApplianceApp(handle: Handle) {
 	}
 
 	async function connect(signal: AbortSignal) {
-		const handshakeSamples: Array<string> = []
-		const onWindowMessage = (event: MessageEvent) => {
-			const summary = toBridgeEventSummary(event)
-			handshakeSamples.push(summary)
-			if (handshakeSamples.length > 8) handshakeSamples.shift()
-			if (event.source !== window.parent) {
-				bridgeDebugBreak('message-from-non-parent-source', {
-					summary,
-					origin: event.origin,
-				})
-			}
-		}
-		window.addEventListener('message', onWindowMessage)
-
 		try {
 			connectionStatus = 'connecting'
 			connectionMessage = 'Connecting to host…'
@@ -595,7 +552,6 @@ export function McpApplianceApp(handle: Handle) {
 			}
 
 			nextApp.onhostcontextchanged = (context) => {
-				bridgeDebugBreak('host-context-changed', context)
 				hostContext = { ...hostContext, ...context }
 				handle.update()
 			}
@@ -605,11 +561,6 @@ export function McpApplianceApp(handle: Handle) {
 			}))
 
 			nextApp.oncalltool = handleToolCall
-			bridgeDebugBreak('before-app-connect', {
-				parentEqualsTop: window.parent === window.top,
-				location: window.location.href,
-				hostContext,
-			})
 			const timeoutMs = 8000
 			let timeoutHandle: ReturnType<typeof setTimeout> | null = null
 			try {
@@ -617,13 +568,9 @@ export function McpApplianceApp(handle: Handle) {
 					nextApp.connect(),
 					new Promise<never>((_, reject) => {
 						timeoutHandle = setTimeout(() => {
-							const sampleText =
-								handshakeSamples.length > 0
-									? handshakeSamples.join(' | ')
-									: 'no message events captured'
 							reject(
 								new Error(
-									`Host handshake timed out after ${timeoutMs}ms. Recent bridge events: ${sampleText}`,
+									`Host handshake timed out after ${timeoutMs}ms.`,
 								),
 							)
 						}, timeoutMs)
@@ -636,15 +583,10 @@ export function McpApplianceApp(handle: Handle) {
 			// connect() resolved successfully, so prefer connected state even if this
 			// task signal was aborted during intermediate updates.
 			hostContext = nextApp.getHostContext()
-			bridgeDebugBreak('connect-resolved', hostContext)
 			connectionStatus = 'connected'
 			connectionMessage = 'Connected.'
 			handle.update()
 		} catch (error) {
-			bridgeDebugBreak('connect-catch', {
-				error: error instanceof Error ? error.message : String(error),
-				handshakeSamples,
-			})
 			connectionStatus = 'error'
 			connectionMessage = null
 			const message =
@@ -653,8 +595,6 @@ export function McpApplianceApp(handle: Handle) {
 				? `${message} (task signal aborted during handshake)`
 				: message
 			handle.update()
-		} finally {
-			window.removeEventListener('message', onWindowMessage)
 		}
 	}
 

--- a/client/mcp-appliance-app.tsx
+++ b/client/mcp-appliance-app.tsx
@@ -569,9 +569,7 @@ export function McpApplianceApp(handle: Handle) {
 					new Promise<never>((_, reject) => {
 						timeoutHandle = setTimeout(() => {
 							reject(
-								new Error(
-									`Host handshake timed out after ${timeoutMs}ms.`,
-								),
+								new Error(`Host handshake timed out after ${timeoutMs}ms.`),
 							)
 						}, timeoutMs)
 					}),

--- a/client/mcp-appliance-app.tsx
+++ b/client/mcp-appliance-app.tsx
@@ -1,0 +1,995 @@
+import { App, type McpUiHostContext } from '@modelcontextprotocol/ext-apps'
+import { type CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { type Handle } from 'remix/component'
+
+type ConnectionStatus = 'connecting' | 'connected' | 'error'
+
+type ApplianceSeed = {
+	id: number
+	name: string
+	watts: number
+	notes: string | null
+}
+
+type ApplianceControl = {
+	enabled: boolean
+	hoursPerDay: number
+	dutyCyclePercent: number
+	startHour: number
+	quantity: number
+	overrideWatts: number | null
+}
+
+type ApplianceWithControl = ApplianceSeed & {
+	control: ApplianceControl
+}
+
+type ApplianceDerived = {
+	effectiveWatts: number
+	dailyKwh: number
+	averageWatts: number
+	hourlyLoadWatts: Array<number>
+}
+
+type ApplianceWithDerived = ApplianceWithControl & {
+	derived: ApplianceDerived
+}
+
+type SimulationTotals = {
+	dailyKwh: number
+	averageWatts: number
+	peakWatts: number
+}
+
+type SimulationSnapshot = {
+	appliances: Array<ApplianceWithDerived>
+	totals: SimulationTotals
+	hourlyLoadWatts: Array<number>
+}
+
+type LaunchPayload = {
+	ok: true
+	appliances: Array<ApplianceSeed>
+	applianceCount: number
+	generatedAt: string
+}
+
+type ToolUpdate = {
+	id?: number
+	name?: string
+	enabled?: boolean
+	hoursPerDay?: number
+	dutyCyclePercent?: number
+	startHour?: number
+	quantity?: number
+	overrideWatts?: number | null
+}
+
+type SimulationToolPayload = {
+	ok: true
+	appliances: Array<{
+		id: number
+		name: string
+		baseWatts: number
+		notes: string | null
+		control: ApplianceControl
+		derived: Omit<ApplianceDerived, 'hourlyLoadWatts'>
+	}>
+	totals: SimulationTotals
+	hourlyLoadWatts: Array<number>
+	updatedAt: string
+}
+
+const appInfo = { name: 'Appliance Energy App', version: '1.0.0' }
+
+function clampNumber(value: number, min: number, max: number) {
+	return Math.min(Math.max(value, min), max)
+}
+
+function toFiniteNumber(value: unknown) {
+	if (typeof value === 'number') return Number.isFinite(value) ? value : null
+	if (typeof value !== 'string') return null
+	const normalized = value.trim()
+	if (!normalized) return null
+	const parsed = Number(normalized)
+	return Number.isFinite(parsed) ? parsed : null
+}
+
+function normalizeControl(control: ApplianceControl): ApplianceControl {
+	return {
+		enabled: control.enabled,
+		hoursPerDay: clampNumber(control.hoursPerDay, 0, 24),
+		dutyCyclePercent: clampNumber(control.dutyCyclePercent, 0, 100),
+		startHour: clampNumber(Math.round(control.startHour), 0, 23),
+		quantity: clampNumber(Math.round(control.quantity), 1, 100),
+		overrideWatts:
+			control.overrideWatts == null
+				? null
+				: clampNumber(control.overrideWatts, 1, 100_000),
+	}
+}
+
+function createDefaultControl(): ApplianceControl {
+	return {
+		enabled: true,
+		hoursPerDay: 8,
+		dutyCyclePercent: 100,
+		startHour: 6,
+		quantity: 1,
+		overrideWatts: null,
+	}
+}
+
+function buildApplianceWithControl(seed: ApplianceSeed): ApplianceWithControl {
+	return {
+		...seed,
+		control: createDefaultControl(),
+	}
+}
+
+function getEffectiveWatts(appliance: ApplianceWithControl) {
+	return appliance.control.overrideWatts ?? appliance.watts
+}
+
+function getOverlap(
+	intervalStart: number,
+	intervalEnd: number,
+	windowStart: number,
+	windowEnd: number,
+) {
+	const start = Math.max(intervalStart, windowStart)
+	const end = Math.min(intervalEnd, windowEnd)
+	return Math.max(0, end - start)
+}
+
+function calculateHourlyLoad(
+	control: ApplianceControl,
+	effectiveWatts: number,
+) {
+	const hourly = Array.from({ length: 24 }, () => 0)
+	if (!control.enabled) return hourly
+	if (effectiveWatts <= 0) return hourly
+
+	const runHours = clampNumber(control.hoursPerDay, 0, 24)
+	if (runHours <= 0) return hourly
+	const dutyMultiplier = clampNumber(control.dutyCyclePercent, 0, 100) / 100
+	if (dutyMultiplier <= 0) return hourly
+
+	const quantity = clampNumber(control.quantity, 1, 100)
+	const watts = effectiveWatts * quantity * dutyMultiplier
+	const startHour = clampNumber(control.startHour, 0, 23)
+	const endHour = startHour + runHours
+
+	for (let hour = 0; hour < 24; hour++) {
+		const intervalStart = hour
+		const intervalEnd = hour + 1
+		const sameDayOverlap = getOverlap(
+			intervalStart,
+			intervalEnd,
+			startHour,
+			Math.min(endHour, 24),
+		)
+		const wrappedOverlap =
+			endHour > 24 ? getOverlap(intervalStart, intervalEnd, 0, endHour - 24) : 0
+		const overlap = sameDayOverlap + wrappedOverlap
+		hourly[hour] = watts * overlap
+	}
+
+	return hourly
+}
+
+function calculateApplianceDerived(
+	appliance: ApplianceWithControl,
+): ApplianceWithDerived {
+	const effectiveWatts = getEffectiveWatts(appliance)
+	const hourlyLoadWatts = calculateHourlyLoad(appliance.control, effectiveWatts)
+	const totalWattHours = hourlyLoadWatts.reduce((sum, value) => sum + value, 0)
+	const dailyKwh = totalWattHours / 1000
+	const averageWatts = totalWattHours / 24
+
+	return {
+		...appliance,
+		derived: {
+			effectiveWatts,
+			dailyKwh,
+			averageWatts,
+			hourlyLoadWatts,
+		},
+	}
+}
+
+function calculateSimulation(
+	appliances: Array<ApplianceWithControl>,
+): SimulationSnapshot {
+	const appliancesWithDerived = appliances.map(calculateApplianceDerived)
+	const hourlyLoadWatts = Array.from({ length: 24 }, (_value, hour) =>
+		appliancesWithDerived.reduce(
+			(sum, appliance) => sum + (appliance.derived.hourlyLoadWatts[hour] ?? 0),
+			0,
+		),
+	)
+	const totalWattHours = hourlyLoadWatts.reduce((sum, value) => sum + value, 0)
+	const dailyKwh = totalWattHours / 1000
+	const averageWatts = totalWattHours / 24
+	const peakWatts = hourlyLoadWatts.reduce(
+		(maxValue, value) => Math.max(maxValue, value),
+		0,
+	)
+
+	return {
+		appliances: appliancesWithDerived,
+		totals: { dailyKwh, averageWatts, peakWatts },
+		hourlyLoadWatts,
+	}
+}
+
+function toSimulationToolPayload(
+	snapshot: SimulationSnapshot,
+): SimulationToolPayload {
+	return {
+		ok: true,
+		appliances: snapshot.appliances.map((appliance) => ({
+			id: appliance.id,
+			name: appliance.name,
+			baseWatts: appliance.watts,
+			notes: appliance.notes,
+			control: appliance.control,
+			derived: {
+				effectiveWatts: appliance.derived.effectiveWatts,
+				dailyKwh: appliance.derived.dailyKwh,
+				averageWatts: appliance.derived.averageWatts,
+			},
+		})),
+		totals: snapshot.totals,
+		hourlyLoadWatts: snapshot.hourlyLoadWatts,
+		updatedAt: new Date().toISOString(),
+	}
+}
+
+function formatWatts(value: number) {
+	return `${Math.round(value).toLocaleString()} W`
+}
+
+function formatKwh(value: number) {
+	return `${value.toFixed(2)} kWh`
+}
+
+function isLaunchPayload(value: unknown): value is LaunchPayload {
+	if (!value || typeof value !== 'object') return false
+	const payload = value as Record<string, unknown>
+	return (
+		payload.ok === true &&
+		Array.isArray(payload.appliances) &&
+		typeof payload.applianceCount === 'number'
+	)
+}
+
+export function McpApplianceApp(handle: Handle) {
+	let hostContext: McpUiHostContext | undefined
+	let connectionStatus: ConnectionStatus = 'connecting'
+	let connectionMessage: string | null = 'Connecting to host…'
+	let loadError: string | null = null
+	let isConnectQueued = false
+
+	let applianceRows: Array<ApplianceWithControl> = []
+	let selectedApplianceId: number | null = null
+	let simulation = calculateSimulation(applianceRows)
+
+	function updateSimulation(nextRows: Array<ApplianceWithControl>) {
+		applianceRows = nextRows
+		simulation = calculateSimulation(applianceRows)
+		if (selectedApplianceId == null && applianceRows.length > 0) {
+			selectedApplianceId = applianceRows[0]?.id ?? null
+		}
+		if (selectedApplianceId != null) {
+			const exists = applianceRows.some(
+				(item) => item.id === selectedApplianceId,
+			)
+			if (!exists) {
+				selectedApplianceId = applianceRows[0]?.id ?? null
+			}
+		}
+	}
+
+	function hydrateFromLaunchPayload(payload: LaunchPayload) {
+		const rows = payload.appliances.map(buildApplianceWithControl)
+		updateSimulation(rows)
+		connectionMessage = `Loaded ${payload.applianceCount} appliance(s).`
+		loadError = null
+		handle.update()
+	}
+
+	function findApplianceIndex(update: ToolUpdate) {
+		if (typeof update.id === 'number') {
+			return applianceRows.findIndex((item) => item.id === update.id)
+		}
+		if (typeof update.name === 'string' && update.name.trim()) {
+			const normalized = update.name.trim().toLowerCase()
+			return applianceRows.findIndex(
+				(item) => item.name.trim().toLowerCase() === normalized,
+			)
+		}
+		return -1
+	}
+
+	function applyToolUpdates(updates: Array<ToolUpdate>) {
+		const nextRows = [...applianceRows]
+		const missingTargets: Array<string> = []
+		let appliedCount = 0
+
+		for (const update of updates) {
+			const index = findApplianceIndex(update)
+			if (index < 0) {
+				const label =
+					typeof update.id === 'number'
+						? `id:${update.id}`
+						: typeof update.name === 'string'
+							? `name:${update.name}`
+							: 'unknown'
+				missingTargets.push(label)
+				continue
+			}
+			const current = nextRows[index]
+			if (!current) continue
+			const nextControl = normalizeControl({
+				enabled:
+					typeof update.enabled === 'boolean'
+						? update.enabled
+						: current.control.enabled,
+				hoursPerDay:
+					toFiniteNumber(update.hoursPerDay) ?? current.control.hoursPerDay,
+				dutyCyclePercent:
+					toFiniteNumber(update.dutyCyclePercent) ??
+					current.control.dutyCyclePercent,
+				startHour:
+					toFiniteNumber(update.startHour) ?? current.control.startHour,
+				quantity: toFiniteNumber(update.quantity) ?? current.control.quantity,
+				overrideWatts:
+					update.overrideWatts === null
+						? null
+						: (toFiniteNumber(update.overrideWatts) ??
+							current.control.overrideWatts),
+			})
+			nextRows[index] = { ...current, control: nextControl }
+			appliedCount += 1
+		}
+
+		if (appliedCount > 0) {
+			updateSimulation(nextRows)
+			loadError = null
+			handle.update()
+		}
+
+		return { appliedCount, missingTargets }
+	}
+
+	function resetControls(ids: Array<number> | null) {
+		if (!ids || ids.length === 0) {
+			updateSimulation(
+				applianceRows.map((item) => ({
+					...item,
+					control: createDefaultControl(),
+				})),
+			)
+			handle.update()
+			return applianceRows.length
+		}
+		const targetSet = new Set(ids)
+		let changedCount = 0
+		const nextRows = applianceRows.map((item) => {
+			if (!targetSet.has(item.id)) return item
+			changedCount += 1
+			return { ...item, control: createDefaultControl() }
+		})
+		updateSimulation(nextRows)
+		handle.update()
+		return changedCount
+	}
+
+	async function handleToolCall(
+		params: Parameters<NonNullable<App['oncalltool']>>[0],
+	): Promise<CallToolResult> {
+		if (params.name === 'get_appliance_simulation_state') {
+			const payload = toSimulationToolPayload(simulation)
+			return {
+				content: [
+					{
+						type: 'text',
+						text: `Current daily load is ${formatKwh(payload.totals.dailyKwh)} with a peak of ${formatWatts(payload.totals.peakWatts)}.`,
+					},
+					{ type: 'text', text: JSON.stringify(payload) },
+				],
+				structuredContent: payload,
+			}
+		}
+
+		if (params.name === 'set_appliance_controls') {
+			const args =
+				params.arguments && typeof params.arguments === 'object'
+					? (params.arguments as Record<string, unknown>)
+					: {}
+			const updates = Array.isArray(args.updates)
+				? (args.updates as Array<ToolUpdate>)
+				: []
+			if (updates.length === 0) {
+				return {
+					isError: true,
+					content: [
+						{
+							type: 'text',
+							text: 'Expected non-empty updates array for set_appliance_controls.',
+						},
+					],
+				}
+			}
+			const { appliedCount, missingTargets } = applyToolUpdates(updates)
+			const payload = toSimulationToolPayload(simulation)
+			const missingText =
+				missingTargets.length > 0
+					? ` Missing targets: ${missingTargets.join(', ')}.`
+					: ''
+			return {
+				content: [
+					{
+						type: 'text',
+						text: `Applied ${appliedCount} control update(s).${missingText} Daily load is ${formatKwh(payload.totals.dailyKwh)}.`,
+					},
+					{ type: 'text', text: JSON.stringify(payload) },
+				],
+				structuredContent: payload,
+			}
+		}
+
+		if (params.name === 'reset_appliance_controls') {
+			const args =
+				params.arguments && typeof params.arguments === 'object'
+					? (params.arguments as Record<string, unknown>)
+					: {}
+			const ids = Array.isArray(args.ids)
+				? args.ids
+						.map((value) => toFiniteNumber(value))
+						.filter((value): value is number => value != null)
+						.map((value) => Math.round(value))
+				: null
+			const changedCount = resetControls(ids)
+			const payload = toSimulationToolPayload(simulation)
+			return {
+				content: [
+					{
+						type: 'text',
+						text: `Reset controls for ${changedCount} appliance(s). Daily load is ${formatKwh(payload.totals.dailyKwh)}.`,
+					},
+					{ type: 'text', text: JSON.stringify(payload) },
+				],
+				structuredContent: payload,
+			}
+		}
+
+		return {
+			isError: true,
+			content: [
+				{
+					type: 'text',
+					text: `Unknown app tool: ${params.name}`,
+				},
+			],
+		}
+	}
+
+	async function connect(signal: AbortSignal) {
+		try {
+			connectionStatus = 'connecting'
+			connectionMessage = 'Connecting to host…'
+			loadError = null
+			handle.update()
+
+			const nextApp = new App(appInfo, { tools: { listChanged: false } })
+
+			nextApp.ontoolresult = (result) => {
+				const payload = (result as { structuredContent?: unknown })
+					.structuredContent
+				if (!isLaunchPayload(payload)) return
+				hydrateFromLaunchPayload(payload)
+			}
+
+			nextApp.onhostcontextchanged = (context) => {
+				hostContext = { ...hostContext, ...context }
+				handle.update()
+			}
+
+			nextApp.onlisttools = async () => ({
+				tools: [
+					'get_appliance_simulation_state',
+					'set_appliance_controls',
+					'reset_appliance_controls',
+				],
+			})
+
+			nextApp.oncalltool = handleToolCall
+
+			await nextApp.connect()
+			if (signal.aborted) return
+
+			hostContext = nextApp.getHostContext()
+			connectionStatus = 'connected'
+			connectionMessage = 'Connected.'
+			handle.update()
+		} catch (error) {
+			if (signal.aborted) return
+			connectionStatus = 'error'
+			connectionMessage = null
+			loadError = error instanceof Error ? error.message : 'Connection failed.'
+			handle.update()
+		}
+	}
+
+	function getSelectedAppliance() {
+		if (selectedApplianceId == null) return null
+		return (
+			simulation.appliances.find((item) => item.id === selectedApplianceId) ??
+			null
+		)
+	}
+
+	function updateSelectedControl(
+		key: keyof ApplianceControl,
+		value: boolean | number | null,
+	) {
+		const selected = getSelectedAppliance()
+		if (!selected) return
+		const nextRows = applianceRows.map((item) => {
+			if (item.id !== selected.id) return item
+			const nextControl = normalizeControl({
+				...item.control,
+				[key]: value as never,
+			})
+			return { ...item, control: nextControl }
+		})
+		updateSimulation(nextRows)
+		handle.update()
+	}
+
+	function getSafeAreaPadding() {
+		return {
+			paddingTop: hostContext?.safeAreaInsets?.top ?? 0,
+			paddingRight: hostContext?.safeAreaInsets?.right ?? 0,
+			paddingBottom: hostContext?.safeAreaInsets?.bottom ?? 0,
+			paddingLeft: hostContext?.safeAreaInsets?.left ?? 0,
+		}
+	}
+
+	return () => {
+		if (!isConnectQueued) {
+			isConnectQueued = true
+			handle.queueTask(connect)
+		}
+
+		const selected = getSelectedAppliance()
+		const hourlyMax = simulation.hourlyLoadWatts.reduce(
+			(maxValue, value) => Math.max(maxValue, value),
+			0,
+		)
+
+		return (
+			<main
+				style={{
+					...getSafeAreaPadding(),
+					height: '100%',
+					boxSizing: 'border-box',
+					display: 'grid',
+					gridTemplateRows: 'auto auto 1fr',
+					gap: '1rem',
+					padding: '1rem',
+					background: '#ffffff',
+					color: '#111827',
+				}}
+			>
+				<header
+					style={{
+						display: 'flex',
+						justifyContent: 'space-between',
+						alignItems: 'center',
+						gap: '1rem',
+						flexWrap: 'wrap',
+					}}
+				>
+					<div style={{ display: 'grid', gap: '0.25rem' }}>
+						<h1 style={{ margin: 0, fontSize: '1.25rem' }}>
+							Appliance Energy Simulator
+						</h1>
+						<p style={{ margin: 0, color: '#4b5563' }}>
+							Local-only appliance knobs and load calculations.
+						</p>
+					</div>
+					<p
+						style={{
+							margin: 0,
+							fontWeight: 600,
+							color:
+								connectionStatus === 'error'
+									? '#b91c1c'
+									: connectionStatus === 'connected'
+										? '#047857'
+										: '#92400e',
+						}}
+					>
+						{connectionStatus === 'connected'
+							? 'Connected'
+							: connectionStatus === 'error'
+								? 'Connection error'
+								: 'Connecting…'}
+					</p>
+				</header>
+
+				<section
+					style={{
+						display: 'grid',
+						gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+						gap: '0.75rem',
+					}}
+				>
+					<article
+						style={{
+							border: '1px solid #e5e7eb',
+							borderRadius: '0.75rem',
+							padding: '0.75rem',
+							display: 'grid',
+							gap: '0.25rem',
+						}}
+					>
+						<p style={{ margin: 0, color: '#6b7280' }}>Daily energy</p>
+						<p style={{ margin: 0, fontSize: '1.125rem', fontWeight: 600 }}>
+							{formatKwh(simulation.totals.dailyKwh)}
+						</p>
+					</article>
+					<article
+						style={{
+							border: '1px solid #e5e7eb',
+							borderRadius: '0.75rem',
+							padding: '0.75rem',
+							display: 'grid',
+							gap: '0.25rem',
+						}}
+					>
+						<p style={{ margin: 0, color: '#6b7280' }}>Peak load</p>
+						<p style={{ margin: 0, fontSize: '1.125rem', fontWeight: 600 }}>
+							{formatWatts(simulation.totals.peakWatts)}
+						</p>
+					</article>
+					<article
+						style={{
+							border: '1px solid #e5e7eb',
+							borderRadius: '0.75rem',
+							padding: '0.75rem',
+							display: 'grid',
+							gap: '0.25rem',
+						}}
+					>
+						<p style={{ margin: 0, color: '#6b7280' }}>Average load</p>
+						<p style={{ margin: 0, fontSize: '1.125rem', fontWeight: 600 }}>
+							{formatWatts(simulation.totals.averageWatts)}
+						</p>
+					</article>
+				</section>
+
+				<section
+					style={{
+						display: 'grid',
+						gridTemplateColumns: 'minmax(0, 18rem) minmax(0, 1fr)',
+						gap: '1rem',
+						minHeight: 0,
+					}}
+				>
+					<aside
+						style={{
+							border: '1px solid #e5e7eb',
+							borderRadius: '0.75rem',
+							padding: '0.75rem',
+							display: 'grid',
+							gap: '0.75rem',
+							alignContent: 'start',
+							overflow: 'auto',
+						}}
+					>
+						<label style={{ display: 'grid', gap: '0.35rem' }}>
+							<span style={{ fontWeight: 600 }}>Select appliance</span>
+							<select
+								value={selectedApplianceId ?? ''}
+								on={{
+									change: (event) => {
+										if (!(event.currentTarget instanceof HTMLSelectElement))
+											return
+										const nextId = toFiniteNumber(event.currentTarget.value)
+										selectedApplianceId =
+											nextId == null ? null : Math.round(nextId)
+										handle.update()
+									},
+								}}
+								style={{
+									padding: '0.5rem',
+									borderRadius: '0.5rem',
+									border: '1px solid #d1d5db',
+									background: '#fff',
+								}}
+							>
+								<option value="">Select…</option>
+								{simulation.appliances.map((appliance) => (
+									<option key={appliance.id} value={appliance.id}>
+										{appliance.name}
+									</option>
+								))}
+							</select>
+						</label>
+
+						<ul
+							style={{
+								margin: 0,
+								paddingLeft: '1.1rem',
+								display: 'grid',
+								gap: '0.35rem',
+							}}
+						>
+							{simulation.appliances.map((appliance) => (
+								<li key={appliance.id}>
+									<strong>{appliance.name}</strong> —{' '}
+									{formatKwh(appliance.derived.dailyKwh)}
+								</li>
+							))}
+						</ul>
+					</aside>
+
+					<div
+						style={{
+							border: '1px solid #e5e7eb',
+							borderRadius: '0.75rem',
+							padding: '0.75rem',
+							display: 'grid',
+							gap: '0.75rem',
+							alignContent: 'start',
+							overflow: 'auto',
+						}}
+					>
+						{connectionMessage ? (
+							<p style={{ margin: 0, color: '#6b7280' }}>{connectionMessage}</p>
+						) : null}
+						{loadError ? (
+							<p style={{ margin: 0, color: '#b91c1c' }} role="alert">
+								{loadError}
+							</p>
+						) : null}
+
+						{selected ? (
+							<section style={{ display: 'grid', gap: '0.75rem' }}>
+								<header style={{ display: 'grid', gap: '0.35rem' }}>
+									<h2 style={{ margin: 0, fontSize: '1rem' }}>
+										{selected.name}
+									</h2>
+									<p style={{ margin: 0, color: '#6b7280' }}>
+										Base: {formatWatts(selected.watts)} · Effective:{' '}
+										{formatWatts(selected.derived.effectiveWatts)}
+									</p>
+									{selected.notes ? (
+										<p style={{ margin: 0, color: '#6b7280' }}>
+											{selected.notes}
+										</p>
+									) : null}
+								</header>
+
+								<label
+									style={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: '0.5rem',
+									}}
+								>
+									<input
+										type="checkbox"
+										checked={selected.control.enabled}
+										on={{
+											change: (event) => {
+												if (!(event.currentTarget instanceof HTMLInputElement))
+													return
+												updateSelectedControl(
+													'enabled',
+													event.currentTarget.checked,
+												)
+											},
+										}}
+									/>
+									<span>Enabled</span>
+								</label>
+
+								<label style={{ display: 'grid', gap: '0.35rem' }}>
+									<span>Hours per day</span>
+									<input
+										type="number"
+										min="0"
+										max="24"
+										step="0.25"
+										value={selected.control.hoursPerDay}
+										on={{
+											input: (event) => {
+												if (!(event.currentTarget instanceof HTMLInputElement))
+													return
+												const next = toFiniteNumber(event.currentTarget.value)
+												if (next == null) return
+												updateSelectedControl('hoursPerDay', next)
+											},
+										}}
+										style={{
+											padding: '0.5rem',
+											borderRadius: '0.5rem',
+											border: '1px solid #d1d5db',
+										}}
+									/>
+								</label>
+
+								<label style={{ display: 'grid', gap: '0.35rem' }}>
+									<span>Duty cycle (%)</span>
+									<input
+										type="number"
+										min="0"
+										max="100"
+										step="1"
+										value={selected.control.dutyCyclePercent}
+										on={{
+											input: (event) => {
+												if (!(event.currentTarget instanceof HTMLInputElement))
+													return
+												const next = toFiniteNumber(event.currentTarget.value)
+												if (next == null) return
+												updateSelectedControl('dutyCyclePercent', next)
+											},
+										}}
+										style={{
+											padding: '0.5rem',
+											borderRadius: '0.5rem',
+											border: '1px solid #d1d5db',
+										}}
+									/>
+								</label>
+
+								<label style={{ display: 'grid', gap: '0.35rem' }}>
+									<span>Start hour (0–23)</span>
+									<input
+										type="number"
+										min="0"
+										max="23"
+										step="1"
+										value={selected.control.startHour}
+										on={{
+											input: (event) => {
+												if (!(event.currentTarget instanceof HTMLInputElement))
+													return
+												const next = toFiniteNumber(event.currentTarget.value)
+												if (next == null) return
+												updateSelectedControl('startHour', next)
+											},
+										}}
+										style={{
+											padding: '0.5rem',
+											borderRadius: '0.5rem',
+											border: '1px solid #d1d5db',
+										}}
+									/>
+								</label>
+
+								<label style={{ display: 'grid', gap: '0.35rem' }}>
+									<span>Quantity</span>
+									<input
+										type="number"
+										min="1"
+										max="100"
+										step="1"
+										value={selected.control.quantity}
+										on={{
+											input: (event) => {
+												if (!(event.currentTarget instanceof HTMLInputElement))
+													return
+												const next = toFiniteNumber(event.currentTarget.value)
+												if (next == null) return
+												updateSelectedControl('quantity', next)
+											},
+										}}
+										style={{
+											padding: '0.5rem',
+											borderRadius: '0.5rem',
+											border: '1px solid #d1d5db',
+										}}
+									/>
+								</label>
+
+								<label style={{ display: 'grid', gap: '0.35rem' }}>
+									<span>Override watts (optional)</span>
+									<input
+										type="number"
+										min="1"
+										step="1"
+										placeholder="Use base watts when blank"
+										value={selected.control.overrideWatts ?? ''}
+										on={{
+											input: (event) => {
+												if (!(event.currentTarget instanceof HTMLInputElement))
+													return
+												const value = event.currentTarget.value.trim()
+												if (!value) {
+													updateSelectedControl('overrideWatts', null)
+													return
+												}
+												const next = toFiniteNumber(value)
+												if (next == null) return
+												updateSelectedControl('overrideWatts', next)
+											},
+										}}
+										style={{
+											padding: '0.5rem',
+											borderRadius: '0.5rem',
+											border: '1px solid #d1d5db',
+										}}
+									/>
+								</label>
+
+								<p style={{ margin: 0 }}>
+									<strong>Appliance daily load:</strong>{' '}
+									{formatKwh(selected.derived.dailyKwh)}
+								</p>
+							</section>
+						) : (
+							<p style={{ margin: 0, color: '#6b7280' }}>
+								Select an appliance to adjust knobs.
+							</p>
+						)}
+
+						<section style={{ display: 'grid', gap: '0.5rem' }}>
+							<h3 style={{ margin: 0, fontSize: '0.95rem' }}>
+								Hourly load profile
+							</h3>
+							<div
+								style={{
+									display: 'grid',
+									gridTemplateColumns: 'repeat(24, minmax(0, 1fr))',
+									alignItems: 'end',
+									gap: '0.2rem',
+									height: '7.5rem',
+									border: '1px solid #e5e7eb',
+									borderRadius: '0.5rem',
+									padding: '0.4rem',
+									background: '#f9fafb',
+								}}
+							>
+								{simulation.hourlyLoadWatts.map((value, hour) => {
+									const ratio = hourlyMax > 0 ? value / hourlyMax : 0
+									return (
+										<div
+											key={hour}
+											title={`${hour}:00 · ${formatWatts(value)}`}
+											style={{
+												height: `${Math.max(6, ratio * 100)}%`,
+												borderRadius: '0.2rem',
+												background: '#2563eb',
+											}}
+										/>
+									)
+								})}
+							</div>
+							<div
+								style={{
+									display: 'grid',
+									gridTemplateColumns: 'repeat(12, minmax(0, 1fr))',
+									fontSize: '0.75rem',
+									color: '#6b7280',
+								}}
+							>
+								{Array.from({ length: 12 }, (_value, index) => (
+									<span key={index} style={{ textAlign: 'center' }}>
+										{String(index * 2).padStart(2, '0')}
+									</span>
+								))}
+							</div>
+						</section>
+					</div>
+				</section>
+			</main>
+		)
+	}
+}

--- a/client/mcp-appliance-entry.tsx
+++ b/client/mcp-appliance-entry.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from 'remix/component'
+import { McpApplianceApp } from './mcp-appliance-app.tsx'
+
+const rootElement = document.getElementById('root') ?? document.body
+createRoot(rootElement).render(<McpApplianceApp />)

--- a/mcp/tools.ts
+++ b/mcp/tools.ts
@@ -170,9 +170,9 @@ function createApplianceAppHtml(baseUrl: string) {
 				padding: 0;
 			}
 			body {
-				font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-				background: #ffffff;
-				color: #1f2937;
+				font-family: var(--font-family), system-ui, sans-serif;
+				background: var(--color-background);
+				color: var(--color-text);
 			}
 		</style>
 	</head>

--- a/mcp/tools.ts
+++ b/mcp/tools.ts
@@ -1,9 +1,24 @@
 import { z } from 'zod'
+import {
+	registerAppResource,
+	registerAppTool,
+	RESOURCE_MIME_TYPE,
+} from '@modelcontextprotocol/ext-apps/server'
 import { createApplianceStore } from '../worker/appliances.ts'
 import { applianceSummarySchema } from '../worker/model-schemas.ts'
 import { type MCP } from './index.ts'
 
 type ApplianceSummary = z.infer<typeof applianceSummarySchema>
+type ApplianceAppSeed = Pick<
+	ApplianceSummary,
+	'id' | 'name' | 'watts' | 'notes'
+>
+type OpenApplianceEnergyAppPayload = {
+	ok: true
+	appliances: Array<ApplianceAppSeed>
+	applianceCount: number
+	generatedAt: string
+}
 
 type ApplianceInput = {
 	name: string
@@ -137,6 +152,44 @@ function resolveOptionalNotes(input: ApplianceEditInput) {
 
 function createStore(agent: MCP) {
 	return createApplianceStore(agent.getDb())
+}
+
+function createApplianceAppHtml(baseUrl: string) {
+	const appScriptUrl = new URL('/mcp-appliance-app.js', baseUrl).toString()
+	return `<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Appliance Energy Simulator</title>
+		<style>
+			html, body, #root {
+				width: 100%;
+				height: 100%;
+				margin: 0;
+				padding: 0;
+			}
+			body {
+				font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+				background: #ffffff;
+				color: #1f2937;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script src="${appScriptUrl}"></script>
+	</body>
+</html>`
+}
+
+function toApplianceAppSeed(appliance: ApplianceSummary): ApplianceAppSeed {
+	return {
+		id: appliance.id,
+		name: appliance.name,
+		watts: appliance.watts,
+		notes: appliance.notes,
+	}
 }
 
 export async function registerTools(agent: MCP) {
@@ -340,6 +393,74 @@ export async function registerTools(agent: MCP) {
 					{ type: 'text', text: JSON.stringify(payload) },
 				],
 				structuredContent: payload,
+			}
+		},
+	)
+
+	const applianceAppResourceUri = 'ui://home-energy/appliance-simulator'
+
+	registerAppTool(
+		agent.server,
+		'open_appliance_energy_app',
+		{
+			title: 'Open Appliance Energy App',
+			description:
+				'Open the interactive appliance energy app with local per-appliance controls and load chart.',
+			inputSchema: {},
+			annotations: { readOnlyHint: true },
+			_meta: { ui: { resourceUri: applianceAppResourceUri } },
+		},
+		async () => {
+			const ownerId = await agent.requireOwnerId()
+			const store = createStore(agent)
+			const list = await store.listByOwner(ownerId)
+			const summary = summarizeAppliances(list.map(toSummary))
+			const payload: OpenApplianceEnergyAppPayload = {
+				ok: true,
+				appliances: summary.appliances.map(toApplianceAppSeed),
+				applianceCount: summary.appliances.length,
+				generatedAt: new Date().toISOString(),
+			}
+			return {
+				content: [
+					{
+						type: 'text',
+						text: `Opened appliance energy app with ${summary.appliances.length} appliance(s).`,
+					},
+					{ type: 'text', text: JSON.stringify(payload) },
+				],
+				structuredContent: payload,
+			}
+		},
+	)
+
+	registerAppResource(
+		agent.server,
+		'appliance_energy_app_ui',
+		applianceAppResourceUri,
+		{
+			mimeType: RESOURCE_MIME_TYPE,
+			description: 'Interactive appliance energy simulator app.',
+		},
+		async () => {
+			const baseUrl = agent.requireDomain()
+			const origin = new URL(baseUrl).origin
+			return {
+				contents: [
+					{
+						uri: applianceAppResourceUri,
+						mimeType: RESOURCE_MIME_TYPE,
+						text: createApplianceAppHtml(origin),
+						_meta: {
+							ui: {
+								csp: {
+									resourceDomains: [origin],
+								},
+								prefersBorder: true,
+							},
+						},
+					},
+				],
 			}
 		},
 	)

--- a/mcp/tools.ts
+++ b/mcp/tools.ts
@@ -198,9 +198,9 @@ function getCspDomains(origin: string): string[] {
 	const port = url.port || (url.protocol === 'https:' ? '443' : '80')
 	const origins = [origin]
 	if (url.hostname === 'localhost') {
-		origins.push(`http://127.0.0.1:${port}`)
+		origins.push(`${url.protocol}//127.0.0.1:${port}`)
 	} else if (url.hostname === '127.0.0.1') {
-		origins.push(`http://localhost:${port}`)
+		origins.push(`${url.protocol}//localhost:${port}`)
 	}
 	return [...new Set(origins)]
 }

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   },
   "scripts": {
     "dev": "bun cli.ts",
-    "dev:client": "esbuild client/entry.tsx --bundle --format=esm --target=es2022 --outdir=public --entry-names=client-entry --chunk-names=assets/[name] --asset-names=assets/[name] --jsx=automatic --jsx-import-source=remix/component --watch",
+    "dev:client": "concurrently --kill-others-on-fail -n web,app -c green,blue \"esbuild client/entry.tsx --bundle --format=esm --target=es2022 --outdir=public --entry-names=client-entry --chunk-names=assets/[name] --asset-names=assets/[name] --jsx=automatic --jsx-import-source=remix/component --watch\" \"esbuild client/mcp-appliance-entry.tsx --bundle --format=iife --target=es2022 --outdir=public --entry-names=mcp-appliance-app --asset-names=assets/[name] --jsx=automatic --jsx-import-source=remix/component --watch\"",
     "dev:worker": "bun ./wrangler-env.ts dev --local",
     "deploy": "bun run build && bun ./wrangler-env.ts deploy",
-    "build:client": "esbuild client/entry.tsx --bundle --format=esm --target=es2022 --outdir=public --entry-names=client-entry --chunk-names=assets/[name] --asset-names=assets/[name] --jsx=automatic --jsx-import-source=remix/component",
+    "build:client": "esbuild client/entry.tsx --bundle --format=esm --target=es2022 --outdir=public --entry-names=client-entry --chunk-names=assets/[name] --asset-names=assets/[name] --jsx=automatic --jsx-import-source=remix/component && esbuild client/mcp-appliance-entry.tsx --bundle --format=iife --target=es2022 --outdir=public --entry-names=mcp-appliance-app --asset-names=assets/[name] --jsx=automatic --jsx-import-source=remix/component",
     "build": "bun run build:client && bun ./wrangler-env.ts build",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",

--- a/tasks/04-mcp-appliance-tools.md
+++ b/tasks/04-mcp-appliance-tools.md
@@ -8,6 +8,8 @@ are available outside the Remix UI.
 - Replace the math demo tool with appliance-focused tools
 - Ensure MCP requests are scoped to the authenticated user
 - Provide tools for list, add, delete, and total watts
+- Provide an MCP App launch tool/resource pair for interactive appliance
+  simulation controls
 
 ## Acceptance criteria
 
@@ -15,6 +17,8 @@ are available outside the Remix UI.
 - MCP tools exist for adding and deleting appliances
 - Each tool uses the authenticated user context from MCP auth
 - Tool responses are structured and include watts values
+- MCP Apps hosts can launch a `ui://...` appliance simulator resource via a
+  linked tool (`_meta.ui.resourceUri`)
 
 ## MCP server best practices (from reference servers)
 
@@ -39,6 +43,6 @@ are available outside the Remix UI.
 
 ## Testing
 
-Automated: extend MCP server tests to cover list/add/delete and totals. Manual:
-use an MCP client to add an appliance, list appliances, and read the total watts
-response.
+Automated: extend MCP server tests to cover list/add/delete, totals, and MCP app
+launch payloads. Manual: use an MCP client/host to add an appliance, list
+appliances, read total watts, then launch the appliance simulator app.


### PR DESCRIPTION
Add an interactive MCP Appliance Energy Simulator app with client-side controls and calculations.

This PR introduces a new Remix 3 MCP app that allows users and agents to adjust per-appliance settings (e.g., hours per day, duty cycle) and instantly view simulated energy consumption and load profiles. Agent control is implemented via app-local tools, keeping all simulation logic client-side as requested.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-3b8d8e70-8d83-4b8f-8b70-0378e8e73f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3b8d8e70-8d83-4b8f-8b70-0378e8e73f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new MCP tool/resource endpoints and a sizable new client bundle; risk is mainly around CSP/origin handling and tool payload compatibility rather than core data mutation logic.
> 
> **Overview**
> Adds a new **MCP App** (bundled as `public/mcp-appliance-app.js`) that launches an interactive Appliance Energy Simulator UI with client-side “knobs” (hours/day, duty cycle, start hour, quantity, override watts) and derived metrics (daily kWh, avg/peak watts, hourly load profile), plus app-local tools (`get_appliance_simulation_state`, `set_appliance_controls`, `reset_appliance_controls`) for agent-driven control.
> 
> Extends the MCP server with a new launch tool/resource pair: `open_appliance_energy_app` returns a structured payload of the user’s appliance list and links to a `ui://home-energy/appliance-simulator` resource that serves HTML with CSP domain configuration and cache-busted asset URLs. Updates build/dev scripts to bundle the new app entry, adds e2e coverage for the tool/payload, and documents the simulator in `README.md`/task notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70d52860dc636eade9ed6989061bb2d7b7d39d76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched Appliance Energy Simulator with per-appliance controls, live metrics (daily kWh, peak/average watts) and 24‑hour load profile.
  * Added an app launch tool so hosts can open the Appliance Energy Simulator directly.

* **Documentation**
  * README updated with expanded tool descriptions and detailed Appliance Energy Simulator usage.

* **Tests**
  * Added end-to-end test covering the appliance app launch payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->