### PR TITLE
Mcp app simulation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ simulator UI with per-appliance knobs. App-side interactions stay local to the
 UI session, and server simulation tools keep a session-scoped control state so
 models can iteratively adjust scenarios. While the app is open, tool-result
 notifications now rehydrate the visible UI so model tool calls update the chart
-and controls in place. The app also requests fullscreen mode on connect when
-the host supports it. Both flows calculate:
+and controls in place. The app also requests fullscreen mode on connect when the
+host supports it. Both flows calculate:
 
 - Per-appliance daily kWh
 - Total daily kWh

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ clients.
 The MCP server now includes an app-launch tool that opens an interactive
 simulator UI with per-appliance knobs. App-side interactions stay local to the
 UI session, and server simulation tools keep a session-scoped control state so
-models can iteratively adjust scenarios. Both flows calculate:
+models can iteratively adjust scenarios. The app also requests fullscreen mode
+on connect when the host supports it. Both flows calculate:
 
 - Per-appliance daily kWh
 - Total daily kWh

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ clients.
 
 The MCP server now includes an app-launch tool that opens an interactive
 simulator UI with per-appliance knobs. App-side interactions stay local to the
-UI session, and server simulation tools keep a session-scoped control state so
-models can iteratively adjust scenarios. While the app is open, tool-result
+UI session, and server simulation tools keep an owner-scoped persisted control
+state so models and the open app can iteratively adjust the same scenario.
+While the app is open, tool-result
 notifications now rehydrate the visible UI so model tool calls update the chart
 and controls in place. The app also requests fullscreen mode on connect when the
 host supports it. Both flows calculate:

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ clients.
 The MCP server now includes an app-launch tool that opens an interactive
 simulator UI with per-appliance knobs. App-side interactions stay local to the
 UI session, and server simulation tools keep a session-scoped control state so
-models can iteratively adjust scenarios. The app also requests fullscreen mode
-on connect when the host supports it. Both flows calculate:
+models can iteratively adjust scenarios. While the app is open, tool-result
+notifications now rehydrate the visible UI so model tool calls update the chart
+and controls in place. The app also requests fullscreen mode on connect when
+the host supports it. Both flows calculate:
 
 - Per-appliance daily kWh
 - Total daily kWh

--- a/README.md
+++ b/README.md
@@ -44,11 +44,10 @@ clients.
 The MCP server now includes an app-launch tool that opens an interactive
 simulator UI with per-appliance knobs. App-side interactions stay local to the
 UI session, and server simulation tools keep an owner-scoped persisted control
-state so models and the open app can iteratively adjust the same scenario.
-While the app is open, tool-result
-notifications now rehydrate the visible UI so model tool calls update the chart
-and controls in place. The app also requests fullscreen mode on connect when the
-host supports it. Both flows calculate:
+state so models and the open app can iteratively adjust the same scenario. While
+the app is open, tool-result notifications now rehydrate the visible UI so model
+tool calls update the chart and controls in place. The app also requests
+fullscreen mode on connect when the host supports it. Both flows calculate:
 
 - Per-appliance daily kWh
 - Total daily kWh

--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ clients.
 - Supports deleting appliances to keep totals accurate.
 - Exposes MCP tools for list, add, edit, delete, and total-watts flows.
 - Exposes app-linked MCP simulation tools for reading and updating per-appliance
-  knobs (`get_appliance_simulation_state`,
-  `set_appliance_simulation_controls`, and
-  `reset_appliance_simulation_controls`).
+  knobs (`get_appliance_simulation_state`, `set_appliance_simulation_controls`,
+  and `reset_appliance_simulation_controls`).
 - Exposes an MCP App launch tool (`open_appliance_energy_app`) that opens an
   interactive appliance simulation UI in MCP Apps-compatible hosts.
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ The MCP server now includes an app-launch tool that opens an interactive
 simulator UI with per-appliance knobs. App-side interactions stay local to the
 UI session, and server simulation tools keep an owner-scoped persisted control
 state so models and the open app can iteratively adjust the same scenario. While
-the app is open, tool-result notifications now rehydrate the visible UI so model
-tool calls update the chart and controls in place. The app also requests
-fullscreen mode on connect when the host supports it. Both flows calculate:
+the app is open, a signed websocket stream pushes simulation updates in real
+time, with tool-result hydration and polling as fallback so model tool calls
+update the chart and controls in place. The app also requests fullscreen mode on
+connect when the host supports it. Both flows calculate:
 
 - Per-appliance daily kWh
 - Total daily kWh

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ clients.
 - Shows a running total of watts across all appliances.
 - Supports deleting appliances to keep totals accurate.
 - Exposes MCP tools for list, add, edit, delete, and total-watts flows.
+- Exposes app-linked MCP simulation tools for reading and updating per-appliance
+  knobs (`get_appliance_simulation_state`,
+  `set_appliance_simulation_controls`, and
+  `reset_appliance_simulation_controls`).
 - Exposes an MCP App launch tool (`open_appliance_energy_app`) that opens an
   interactive appliance simulation UI in MCP Apps-compatible hosts.
 
@@ -39,8 +43,9 @@ clients.
 ## MCP App: Appliance Energy Simulator
 
 The MCP server now includes an app-launch tool that opens an interactive
-simulator UI with per-appliance knobs. The simulator uses client-side state only
-(no persistence) and calculates:
+simulator UI with per-appliance knobs. App-side interactions stay local to the
+UI session, and server simulation tools keep a session-scoped control state so
+models can iteratively adjust scenarios. Both flows calculate:
 
 - Per-appliance daily kWh
 - Total daily kWh
@@ -55,6 +60,10 @@ Per-appliance knobs:
 - start hour
 - quantity
 - optional override watts
+
+Models can now twist those knobs via server tools (not only inside the app
+runtime), which aligns with the Excalidraw MCP Apps pattern of exposing
+model-callable app tools on the server.
 
 ## Project Lineage
 

--- a/client/mcp-appliance-app.tsx
+++ b/client/mcp-appliance-app.tsx
@@ -566,6 +566,20 @@ export function McpApplianceApp(handle: Handle) {
 				}
 			}
 			const { appliedCount, missingTargets } = applyToolUpdates(updates)
+			if (connectedApp) {
+				try {
+					const result = await connectedApp.callServerTool({
+						name: 'set_appliance_simulation_controls',
+						arguments: { updates },
+					})
+					const serverPayload = getToolStructuredContent(result)
+					if (isSimulationToolPayload(serverPayload)) {
+						hydrateFromSimulationPayload(serverPayload, { announce: false })
+					}
+				} catch {
+					// Ignore transient sync errors; local updates already applied.
+				}
+			}
 			const payload = toSimulationToolPayload(simulation)
 			const missingText =
 				missingTargets.length > 0
@@ -595,6 +609,21 @@ export function McpApplianceApp(handle: Handle) {
 						.map((value) => Math.round(value))
 				: null
 			const changedCount = resetControls(ids)
+			if (connectedApp) {
+				try {
+					const serverArguments = ids == null ? {} : { ids }
+					const result = await connectedApp.callServerTool({
+						name: 'reset_appliance_simulation_controls',
+						arguments: serverArguments,
+					})
+					const serverPayload = getToolStructuredContent(result)
+					if (isSimulationToolPayload(serverPayload)) {
+						hydrateFromSimulationPayload(serverPayload, { announce: false })
+					}
+				} catch {
+					// Ignore transient sync errors; local reset already applied.
+				}
+			}
 			const payload = toSimulationToolPayload(simulation)
 			return {
 				content: [

--- a/client/mcp-appliance-app.tsx
+++ b/client/mcp-appliance-app.tsx
@@ -324,7 +324,9 @@ function isLaunchPayload(value: unknown): value is LaunchPayload {
 	)
 }
 
-function isSimulationToolPayload(value: unknown): value is SimulationToolPayload {
+function isSimulationToolPayload(
+	value: unknown,
+): value is SimulationToolPayload {
 	if (!value || typeof value !== 'object') return false
 	const payload = value as Record<string, unknown>
 	if (payload.ok !== true) return false

--- a/client/mcp-appliance-app.tsx
+++ b/client/mcp-appliance-app.tsx
@@ -596,12 +596,12 @@ export function McpApplianceApp(handle: Handle) {
 			nextApp.ontoolresult = (result) => {
 				const payload = (result as { structuredContent?: unknown })
 					.structuredContent
-				if (isLaunchPayload(payload)) {
-					hydrateFromLaunchPayload(payload)
-					return
-				}
 				if (isSimulationToolPayload(payload)) {
 					hydrateFromSimulationPayload(payload)
+					return
+				}
+				if (isLaunchPayload(payload)) {
+					hydrateFromLaunchPayload(payload)
 				}
 			}
 

--- a/mcp/mcp-server-e2e.test.ts
+++ b/mcp/mcp-server-e2e.test.ts
@@ -528,7 +528,9 @@ test(
 		expect(appJson.appliances.length).toBe(1)
 		expect(appJson.appliances[0]?.name).toBe('Desk Fan')
 		expect(appJson.generatedAt).toBeDefined()
-		expect(appJson.simulationToolNames).toContain('get_appliance_simulation_state')
+		expect(appJson.simulationToolNames).toContain(
+			'get_appliance_simulation_state',
+		)
 		expect(appJson.simulationToolNames).toContain(
 			'set_appliance_simulation_controls',
 		)
@@ -623,8 +625,8 @@ test(
 				.enabled,
 		).toBe(false)
 		expect(
-			setControlsJson.appliances.find((item) => item.name === 'Toaster')?.control
-				.quantity,
+			setControlsJson.appliances.find((item) => item.name === 'Toaster')
+				?.control.quantity,
 		).toBe(2)
 
 		const resetOneResult = (await mcpClient.client.callTool({
@@ -644,7 +646,8 @@ test(
 		expect(resetOneJson.resetCount).toBe(1)
 		expect(resetOneJson.resetAll).toBe(false)
 		expect(
-			resetOneJson.appliances.find((item) => item.name === 'Fan')?.control.enabled,
+			resetOneJson.appliances.find((item) => item.name === 'Fan')?.control
+				.enabled,
 		).toBe(true)
 
 		const resetAllResult = (await mcpClient.client.callTool({

--- a/mcp/tools.ts
+++ b/mcp/tools.ts
@@ -422,7 +422,9 @@ function withSimulationControls(
 ): Array<ApplianceWithControl> {
 	return appliances.map((appliance) => ({
 		...appliance,
-		control: normalizeControl(controls.get(appliance.id) ?? createDefaultControl()),
+		control: normalizeControl(
+			controls.get(appliance.id) ?? createDefaultControl(),
+		),
 	}))
 }
 
@@ -486,7 +488,8 @@ function applySimulationControlUpdates(
 					: update.dutyCyclePercent,
 			startHour:
 				update.startHour == null ? current.control.startHour : update.startHour,
-			quantity: update.quantity == null ? current.control.quantity : update.quantity,
+			quantity:
+				update.quantity == null ? current.control.quantity : update.quantity,
 			overrideWatts:
 				update.overrideWatts === undefined
 					? current.control.overrideWatts
@@ -502,8 +505,15 @@ async function getSimulationSnapshot(agent: MCP, ownerId: number) {
 	const store = createStore(agent)
 	const list = await store.listByOwner(ownerId)
 	const summary = summarizeAppliances(list.map(toSummary))
-	const controls = syncStoredSimulationControls(agent, ownerId, summary.appliances)
-	const appliancesWithControl = withSimulationControls(summary.appliances, controls)
+	const controls = syncStoredSimulationControls(
+		agent,
+		ownerId,
+		summary.appliances,
+	)
+	const appliancesWithControl = withSimulationControls(
+		summary.appliances,
+		controls,
+	)
 	const snapshot = calculateSimulation(appliancesWithControl)
 	return { appliancesWithControl, snapshot }
 }
@@ -823,7 +833,10 @@ export async function registerTools(agent: MCP) {
 		},
 		async ({ updates }: { updates: Array<ApplianceControlUpdateInput> }) => {
 			const ownerId = await agent.requireOwnerId()
-			const { appliancesWithControl } = await getSimulationSnapshot(agent, ownerId)
+			const { appliancesWithControl } = await getSimulationSnapshot(
+				agent,
+				ownerId,
+			)
 			const { nextAppliances, appliedCount, missingTargets } =
 				applySimulationControlUpdates(appliancesWithControl, updates)
 			persistSimulationControls(agent, ownerId, nextAppliances)

--- a/mcp/tools.ts
+++ b/mcp/tools.ts
@@ -140,14 +140,14 @@ const applianceEditSchema = z
 			data.name != null || data.notes !== undefined || hasPowerInput
 		if (!hasUpdates) {
 			context.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Provide at least one field to update.',
 			})
 		}
 		if (hasPowerInput && data.watts == null) {
 			if (data.amps == null || data.volts == null) {
 				context.addIssue({
-					code: z.ZodIssueCode.custom,
+					code: 'custom',
 					message: 'Provide watts or amps and volts.',
 				})
 			}
@@ -169,7 +169,7 @@ const applianceControlUpdateSchema = z
 		const hasTarget = data.id != null || data.name != null
 		if (!hasTarget) {
 			context.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Provide appliance id or appliance name to update.',
 			})
 		}
@@ -182,7 +182,7 @@ const applianceControlUpdateSchema = z
 			data.overrideWatts !== undefined
 		if (!hasControlUpdate) {
 			context.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: 'custom',
 				message: 'Provide at least one control field to update.',
 			})
 		}

--- a/mcp/tools.ts
+++ b/mcp/tools.ts
@@ -244,7 +244,7 @@ function createStore(agent: MCP) {
 }
 
 function formatKwh(value: number) {
-	return `${value.toFixed(2)}kWh`
+	return `${value.toFixed(2)} kWh`
 }
 
 function clampNumber(value: number, min: number, max: number) {

--- a/mcp/tools.ts
+++ b/mcp/tools.ts
@@ -799,7 +799,12 @@ export async function registerTools(agent: MCP) {
 				'Get appliance knob values, derived totals, and the 24-hour load profile.',
 			inputSchema: {},
 			annotations: { readOnlyHint: true },
-			_meta: { ui: { resourceUri: applianceAppResourceUri } },
+			_meta: {
+				ui: {
+					resourceUri: applianceAppResourceUri,
+					visibility: ['model', 'app'],
+				},
+			},
 		},
 		async () => {
 			const ownerId = await agent.requireOwnerId()
@@ -829,7 +834,12 @@ export async function registerTools(agent: MCP) {
 				updates: z.array(applianceControlUpdateSchema).min(1),
 			},
 			annotations: { idempotentHint: true },
-			_meta: { ui: { resourceUri: applianceAppResourceUri } },
+			_meta: {
+				ui: {
+					resourceUri: applianceAppResourceUri,
+					visibility: ['model', 'app'],
+				},
+			},
 		},
 		async ({ updates }: { updates: Array<ApplianceControlUpdateInput> }) => {
 			const ownerId = await agent.requireOwnerId()
@@ -874,7 +884,12 @@ export async function registerTools(agent: MCP) {
 				ids: z.array(z.number().int().positive()).optional(),
 			},
 			annotations: { idempotentHint: true },
-			_meta: { ui: { resourceUri: applianceAppResourceUri } },
+			_meta: {
+				ui: {
+					resourceUri: applianceAppResourceUri,
+					visibility: ['model', 'app'],
+				},
+			},
 		},
 		async ({ ids }: { ids?: Array<number> }) => {
 			const ownerId = await agent.requireOwnerId()

--- a/worker/simulation-hub.ts
+++ b/worker/simulation-hub.ts
@@ -29,7 +29,9 @@ function toSimulationControl(
 	const startHour = toFiniteNumber(candidate.startHour)
 	const quantity = toFiniteNumber(candidate.quantity)
 	const overrideWatts =
-		candidate.overrideWatts == null ? null : toFiniteNumber(candidate.overrideWatts)
+		candidate.overrideWatts == null
+			? null
+			: toFiniteNumber(candidate.overrideWatts)
 	if (typeof candidate.enabled !== 'boolean') return null
 	if (hoursPerDay == null) return null
 	if (dutyCyclePercent == null) return null

--- a/worker/simulation-hub.ts
+++ b/worker/simulation-hub.ts
@@ -1,0 +1,156 @@
+import type { ApplianceSimulationControl } from '../mcp/index.ts'
+
+const controlsStorageKey = 'simulation-controls'
+
+export const simulationHubConnectPath = '/connect'
+export const simulationHubControlGetPath = '/controls/get'
+export const simulationHubControlSetPath = '/controls/set'
+export const simulationHubPublishPath = '/publish'
+
+type SimulationControlsRecord = Record<string, ApplianceSimulationControl>
+
+type SimulationStreamEnvelope = {
+	type: 'simulation_state_updated'
+	payload: unknown
+}
+
+function isFiniteNumber(value: unknown) {
+	return typeof value === 'number' && Number.isFinite(value)
+}
+
+function toSimulationControl(
+	value: unknown,
+): ApplianceSimulationControl | null {
+	if (!value || typeof value !== 'object') return null
+	const candidate = value as Record<string, unknown>
+	if (typeof candidate.enabled !== 'boolean') return null
+	if (!isFiniteNumber(candidate.hoursPerDay)) return null
+	if (!isFiniteNumber(candidate.dutyCyclePercent)) return null
+	if (!isFiniteNumber(candidate.startHour)) return null
+	if (!isFiniteNumber(candidate.quantity)) return null
+	if (
+		candidate.overrideWatts != null &&
+		!isFiniteNumber(candidate.overrideWatts)
+	) {
+		return null
+	}
+	return {
+		enabled: candidate.enabled,
+		hoursPerDay: candidate.hoursPerDay,
+		dutyCyclePercent: candidate.dutyCyclePercent,
+		startHour: candidate.startHour,
+		quantity: candidate.quantity,
+		overrideWatts:
+			candidate.overrideWatts == null ? null : candidate.overrideWatts,
+	}
+}
+
+function normalizeSimulationControlsRecord(value: unknown) {
+	if (!value || typeof value !== 'object') return {}
+	const normalized: SimulationControlsRecord = {}
+	for (const [idText, control] of Object.entries(
+		value as Record<string, unknown>,
+	)) {
+		const id = Number(idText)
+		if (!Number.isInteger(id) || id <= 0) continue
+		const nextControl = toSimulationControl(control)
+		if (!nextControl) continue
+		normalized[String(id)] = nextControl
+	}
+	return normalized
+}
+
+export class SimulationHub extends DurableObject<Env> {
+	private async readControls() {
+		const stored =
+			await this.ctx.storage.get<SimulationControlsRecord>(controlsStorageKey)
+		return normalizeSimulationControlsRecord(stored)
+	}
+
+	private async writeControls(controls: SimulationControlsRecord) {
+		const ids = Object.keys(controls)
+		if (ids.length === 0) {
+			await this.ctx.storage.delete(controlsStorageKey)
+			return
+		}
+		await this.ctx.storage.put(controlsStorageKey, controls)
+	}
+
+	private async broadcastSimulationUpdate(payload: unknown) {
+		const message: SimulationStreamEnvelope = {
+			type: 'simulation_state_updated',
+			payload,
+		}
+		const encoded = JSON.stringify(message)
+		for (const socket of this.ctx.getWebSockets()) {
+			try {
+				socket.send(encoded)
+			} catch {
+				try {
+					socket.close(1011, 'Simulation update failed.')
+				} catch {
+					// Ignore cleanup failures.
+				}
+			}
+		}
+	}
+
+	private handleWebSocketConnect(request: Request) {
+		const upgradeHeader = request.headers.get('Upgrade')
+		if (!upgradeHeader || upgradeHeader.toLowerCase() !== 'websocket') {
+			return new Response('Expected websocket upgrade.', { status: 426 })
+		}
+		const pair = new WebSocketPair()
+		const clientSocket = pair[0]
+		const serverSocket = pair[1]
+		this.ctx.acceptWebSocket(serverSocket)
+		return new Response(null, {
+			status: 101,
+			webSocket: clientSocket,
+		})
+	}
+
+	async fetch(request: Request) {
+		const url = new URL(request.url)
+		if (url.pathname === simulationHubConnectPath) {
+			return this.handleWebSocketConnect(request)
+		}
+		if (
+			request.method === 'GET' &&
+			url.pathname === simulationHubControlGetPath
+		) {
+			return Response.json({
+				ok: true,
+				controls: await this.readControls(),
+			})
+		}
+		if (
+			request.method === 'POST' &&
+			url.pathname === simulationHubControlSetPath
+		) {
+			const body = (await request.json().catch(() => null)) as {
+				controls?: unknown
+			} | null
+			if (!body) {
+				return new Response('Invalid JSON body.', { status: 400 })
+			}
+			const controls = normalizeSimulationControlsRecord(body.controls)
+			await this.writeControls(controls)
+			return Response.json({ ok: true })
+		}
+		if (
+			request.method === 'POST' &&
+			url.pathname === simulationHubPublishPath
+		) {
+			const body = (await request.json().catch(() => null)) as {
+				payload?: unknown
+			} | null
+			if (!body || body.payload == null) {
+				return new Response('Missing payload.', { status: 400 })
+			}
+			await this.broadcastSimulationUpdate(body.payload)
+			return Response.json({ ok: true })
+		}
+		return new Response('Not found.', { status: 404 })
+	}
+}

--- a/worker/simulation-stream-auth.ts
+++ b/worker/simulation-stream-auth.ts
@@ -1,0 +1,138 @@
+const simulationStreamTokenVersion = 1
+const defaultSimulationStreamTtlMs = 5 * 60 * 1000
+
+type SimulationStreamTokenPayload = {
+	v: number
+	ownerId: number
+	exp: number
+}
+
+export const simulationStreamPath = '/simulation-stream'
+
+function encodeBase64Url(bytes: Uint8Array) {
+	let binary = ''
+	for (const value of bytes) {
+		binary += String.fromCharCode(value)
+	}
+	return btoa(binary)
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=+$/g, '')
+}
+
+function decodeBase64Url(input: string) {
+	if (!input) return null
+	const normalized = input.replace(/-/g, '+').replace(/_/g, '/')
+	const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+	try {
+		const binary = atob(padded)
+		const bytes = new Uint8Array(binary.length)
+		for (let index = 0; index < binary.length; index += 1) {
+			bytes[index] = binary.charCodeAt(index)
+		}
+		return bytes
+	} catch {
+		return null
+	}
+}
+
+async function importSimulationStreamKey(secret: string) {
+	return crypto.subtle.importKey(
+		'raw',
+		new TextEncoder().encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign', 'verify'],
+	)
+}
+
+export async function createSimulationStreamToken({
+	secret,
+	ownerId,
+	now = Date.now(),
+	ttlMs = defaultSimulationStreamTtlMs,
+}: {
+	secret: string
+	ownerId: number
+	now?: number
+	ttlMs?: number
+}) {
+	const expiresAt = now + ttlMs
+	const payload: SimulationStreamTokenPayload = {
+		v: simulationStreamTokenVersion,
+		ownerId,
+		exp: expiresAt,
+	}
+	const payloadEncoded = encodeBase64Url(
+		new TextEncoder().encode(JSON.stringify(payload)),
+	)
+	const key = await importSimulationStreamKey(secret)
+	const signatureBytes = new Uint8Array(
+		await crypto.subtle.sign(
+			'HMAC',
+			key,
+			new TextEncoder().encode(payloadEncoded),
+		),
+	)
+	const signatureEncoded = encodeBase64Url(signatureBytes)
+	return {
+		token: `${payloadEncoded}.${signatureEncoded}`,
+		expiresAt: new Date(expiresAt).toISOString(),
+	}
+}
+
+export async function verifySimulationStreamToken({
+	secret,
+	token,
+	now = Date.now(),
+}: {
+	secret: string
+	token: string
+	now?: number
+}) {
+	const separatorIndex = token.indexOf('.')
+	if (separatorIndex < 1 || separatorIndex >= token.length - 1) {
+		return { ok: false as const }
+	}
+	const payloadEncoded = token.slice(0, separatorIndex)
+	const signatureEncoded = token.slice(separatorIndex + 1)
+	const signatureBytes = decodeBase64Url(signatureEncoded)
+	if (!signatureBytes) {
+		return { ok: false as const }
+	}
+	const key = await importSimulationStreamKey(secret)
+	const isValidSignature = await crypto.subtle.verify(
+		'HMAC',
+		key,
+		signatureBytes,
+		new TextEncoder().encode(payloadEncoded),
+	)
+	if (!isValidSignature) {
+		return { ok: false as const }
+	}
+	const payloadBytes = decodeBase64Url(payloadEncoded)
+	if (!payloadBytes) {
+		return { ok: false as const }
+	}
+	try {
+		const payload = JSON.parse(
+			new TextDecoder().decode(payloadBytes),
+		) as SimulationStreamTokenPayload
+		if (payload.v !== simulationStreamTokenVersion) {
+			return { ok: false as const }
+		}
+		if (!Number.isInteger(payload.ownerId) || payload.ownerId <= 0) {
+			return { ok: false as const }
+		}
+		if (!Number.isFinite(payload.exp) || payload.exp <= now) {
+			return { ok: false as const }
+		}
+		return {
+			ok: true as const,
+			ownerId: payload.ownerId,
+			expiresAt: payload.exp,
+		}
+	} catch {
+		return { ok: false as const }
+	}
+}

--- a/worker/utils.ts
+++ b/worker/utils.ts
@@ -25,6 +25,11 @@ export function withCors<Props>({
 		// Call the original handler
 		const response = await handler(request, env, ctx)
 
+		// Preserve websocket upgrade responses; recreating Response strips webSocket.
+		if (response.status === 101) {
+			return response
+		}
+
 		// Add CORS headers to ALL responses, including early returns
 		const newHeaders = mergeHeaders(response.headers, corsHeaders)
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,6 +9,10 @@
 			"new_sqlite_classes": ["MCP"],
 			"tag": "v1",
 		},
+		{
+			"new_sqlite_classes": ["SimulationHub"],
+			"tag": "v2",
+		},
 	],
 
 	"observability": {
@@ -25,6 +29,10 @@
 					{
 						"class_name": "MCP",
 						"name": "MCP_OBJECT",
+					},
+					{
+						"class_name": "SimulationHub",
+						"name": "SIMULATION_HUB",
 					},
 				],
 			},
@@ -55,6 +63,10 @@
 						"class_name": "MCP",
 						"name": "MCP_OBJECT",
 					},
+					{
+						"class_name": "SimulationHub",
+						"name": "SIMULATION_HUB",
+					},
 				],
 			},
 			"d1_databases": [
@@ -83,6 +95,10 @@
 					{
 						"class_name": "MCP",
 						"name": "MCP_OBJECT",
+					},
+					{
+						"class_name": "SimulationHub",
+						"name": "SIMULATION_HUB",
 					},
 				],
 			},


### PR DESCRIPTION
Expose model-callable simulation tools on the MCP server to enable AI interaction with appliance knobs.

Previously, simulation controls were only internal to the app's UI, preventing AI models from directly manipulating them. This PR aligns the app with the `excalidraw-mcp` pattern by making these controls accessible via server-side tools, allowing models to "twist knobs" and simulate scenarios.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-dfe72e02-545c-4864-8356-f5b000b747f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dfe72e02-545c-4864-8356-f5b000b747f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persisted state and websocket streaming via a Durable Object plus new MCP tools, which increases surface area and has runtime/config risks (bindings, token validation, stream reliability) despite being scoped to simulation controls.
> 
> **Overview**
> Adds **server-side, model-callable appliance simulation tools** to read/update/reset per-appliance “knob” controls and return derived totals + 24h load profile, with controls persisted per owner.
> 
> Introduces a `SimulationHub` Durable Object and signed websocket stream (`/simulation-stream`) so the app can receive real-time simulation updates; appliance CRUD tools now publish simulation snapshots after changes.
> 
> Updates the MCP app UI to hydrate from server tool results, sync knob edits back to the server, and keep state fresh via polling + websocket (plus requesting fullscreen when supported). Tests and docs are expanded to cover the new simulation tool surface and launch payload metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fedae0e691c0c26368c229254744767c18260f90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three simulation tools for per-appliance energy modeling: view state, update controls, and reset (single/all).
  * Introduced adjustable per-appliance parameters (enabled, hours/day, duty cycle %, start hour, quantity, power override); per-appliance and total daily kWh remain calculated.
  * App rehydrates the UI from tool results and requests fullscreen on connect when supported.

* **Documentation**
  * Updated app docs to describe the new simulation tools and behaviors.

* **Tests**
  * End-to-end tests expanded to exercise the new simulation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->